### PR TITLE
Add repolist: autotools, systemtap, ruby

### DIFF
--- a/module-repolist.txt
+++ b/module-repolist.txt
@@ -1,4 +1,7 @@
+autotools
+systemtap
 nginx
 httpd
 freeipa
 perl
+ruby


### PR DESCRIPTION
I updated `README.md` for each modules.
I guess that we have to update `module-repolist.txt` too, right?

https://github.com/modularity-modules/autotools
https://github.com/modularity-modules/systemtap
https://github.com/modularity-modules/ruby
